### PR TITLE
Simplify dom

### DIFF
--- a/WORKAROUND.md
+++ b/WORKAROUND.md
@@ -15,6 +15,7 @@ Neither Livewire nor AlpineJS recognize updates to shadow dom elements. For this
         walk = function(root, callback) {
             if (callback(root) === false) return
 
+            // Needed to activate wire: attributes in shadowRoot content
             if(root.shadowRoot){
                 let node = root.shadowRoot.firstElementChild
 
@@ -23,6 +24,16 @@ Neither Livewire nor AlpineJS recognize updates to shadow dom elements. For this
                     node = node.nextElementSibling
                 }
             }
+
+            // Needed to activate wire: attributes in template content
+            // if(root.content){
+            //     let node = root.content.firstElementChild
+
+            //     while (node) {
+            //         walk(node, callback)
+            //         node = node.nextElementSibling
+            //     }
+            // }
 
             let node = root.firstElementChild
 
@@ -58,38 +69,57 @@ Neither Livewire nor AlpineJS recognize updates to shadow dom elements. For this
             component.walk = overrideComponentWalk
         });
 
-        Livewire.hook('element.updating', (from, to) => {
-            if(typeof from.shadowRoot === 'undefined')
-                return;
+        Livewire.hook('element.initialized', (element, component) => {
+            // Make sure that when Livewire asks if two nodes are the same, we check a TEMPLATE's content
+            // TODO: This workaround alone does not fix template content not being updated.
+            walk(element, el => {
+                if (el.tagName === 'TEMPLATE') {
+                    el.isEqualNode = function(otherEl) {
+                        if(!otherEl.isEqualNode(el))
+                            return false;
 
-            from.shadowRoot.innerHTML = '';
-            const parentEl = from;
-
-            // TODO: Let livewire smart replace the shadowRoot children
-            // WORKAROUND: We're just replacing the whole content in the shadowRoot
-            let count = to.children.length;
-
-            for(let i = 0; i < count; i++){
-                let child = to.children[0]; // Pop from bottom of child stack
-
-                if(child.tagName === 'SCRIPT') {
-                    const script = document.createElement('script');
-                    script.innerHTML = child.innerHTML;
-
-                    to.removeChild(child);
-                    child = script;
+                        return otherEl.content.isEqualNode(el.content);
+                    }
                 }
+            });
+        });
 
-                parentEl.appendChild(child);
+        Livewire.hook('element.updating', (from, to) => {
+            // For whatever reason Livewire wont update my template contents
+            if (from.tagName === 'TEMPLATE') {
+                // Iterate from and to content and compare them
+                let fromContent = from.content
+                let toContent = to.content
+
+                let fromNode = fromContent.firstElementChild
+                let toNode = toContent.firstElementChild
+
+                while (fromNode && toNode) {
+                    if (!fromNode.isEqualNode(toNode)) {
+                        fromNode.innerHTML = toNode.innerHTML;
+                    }
+
+                    fromNode = fromNode.nextElementSibling
+                    toNode = toNode.nextElementSibling
+                }
             }
         });
 
-        Livewire.hook('element.updated', (from) => {
-            if(typeof from.shadowRoot === 'undefined')
+        Livewire.hook('element.updated', (from, component) => {
+            if(from.tagName !== 'SCRIPT')
                 return;
 
-            // Needed so events are attached to children with wire:click again
-            from.__livewire.initialize();
+            if(!from.hasAttribute('data-reexecute-on-livewire-update'))
+                return;
+
+            // Re-execute the script on changes to the script tag
+            const parentEl = from.parentElement;
+            const script = document.createElement('script');
+            // Copy the attributes of the existing script tag
+            [...from.attributes].forEach( attr => { script.setAttribute(attr.nodeName ,attr.nodeValue) })
+            script.innerHTML = from.innerHTML;
+
+            parentEl.replaceChild(script, from);
         });
     };
 

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -4,55 +4,79 @@ namespace Luttje\ScopedComponents;
 
 class Scope
 {
+    private static $currentScriptId = 0;
+
     /**
      * Injects PHP that starts a new scope.
      */
     public static function getStartScope()
     {
-        return <<<SCRIPT_ECHO
-        <div>
-            <?php
-            \$tagConfigs = [
-                [
-                    'tag' => 'noscript'
-                ],
-                [
-                    'tag' => 'template',
-                    'style' => 'display:none'
-                ],
-            ];
-            foreach (\$tagConfigs as \$tagConfig) {
-                extract(\$tagConfig);
+        // Used to generate a random id for reference later
+        $currentScriptId = ++self::$currentScriptId;
 
-                if(isset(\$style))
-                    echo "<\$tag style=\"\$style\">";
-                else
-                    echo "<\$tag>";
-            ?>
-        SCRIPT_ECHO;
+        return <<<SCRIPT_ECHO
+            <div>
+                <?php
+                \$tagConfigs = [
+                    //[
+                    //   'tag' => 'noscript'
+                    //],
+                    [
+                        'tag' => 'template',
+                        'attributes' => [
+                            'style' => 'display:none',
+                            'id' => 'scoped-element-$currentScriptId',
+                        ]
+                    ],
+                ];
+                foreach (\$tagConfigs as \$k => \$tagConfig) {
+                    extract(\$tagConfig);
+
+                    echo "<\$tag";
+
+                    if(isset(\$attributes)) {
+                        foreach (\$attributes as \$attribute => \$value) {
+                            echo " \$attribute=\"\$value\"";
+                        }
+                    }
+
+                    echo ">";
+                ?>
+            SCRIPT_ECHO;
     }
 
     public static function getEndScope()
     {
+        $currentScriptId = self::$currentScriptId;
+
         return <<<SCRIPT_ECHO
             <?php
                 echo "</\$tag>";
             } ?>
 
-            <script>
-            (function(thisScript) {
-                const templateEl = thisScript.previousElementSibling;
-                const parentEl = templateEl.parentNode;
-                const content = templateEl.content.cloneNode(true);
+            <script data-reexecute-on-livewire-update>
+                (function(cacheBreaker) {
+                    const templateEl = document.getElementById('scoped-element-$currentScriptId');
+                    const parentEl = templateEl.parentNode;
+                    const content = templateEl.content.cloneNode(true);
 
-                parentEl.innerHTML = '';
-                const shadow = parentEl.shadowRoot || parentEl.attachShadow({ mode:"open" });
-                shadow.append(content);
+                    const shadow = parentEl.shadowRoot || parentEl.attachShadow({ mode:"open" });
+                    shadow.innerHTML = '';
+                    shadow.append(content);
 
-                document.addEventListener('alpine:init', () => {
-                    Alpine.initTree(shadow);
-                });
-            })(document.currentScript);
+                    let comp = templateEl.closest('[wire\\\\3A id]');
+                    if(comp !== null && comp.__livewire !== undefined) {
+                        console.log(comp.__livewire);
+                        comp.__livewire.initialize();
+                    }
+
+                    if(typeof Alpine !== 'undefined')
+                        Alpine.initTree(shadow);
+                    else
+                        document.addEventListener('alpine:init', () => {
+                            Alpine.initTree(shadow);
+                        });
+                })(<?php echo time(); ?>);
             </script>
         </div>
         SCRIPT_ECHO;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,10 +25,10 @@ class ServiceProvider extends BaseServiceProvider
     public function boot()
     {
         Blade::directive('scope', function () {
-            return \Luttje\ScopedComponents\Scope::getStartScope();;
+            return \Luttje\ScopedComponents\Scope::getStartScope();
         });
         Blade::directive('endscope', function () {
-            return \Luttje\ScopedComponents\Scope::getEndScope();;
+            return \Luttje\ScopedComponents\Scope::getEndScope();
         });
     }
 }


### PR DESCRIPTION
This is still a hacky proof-of-concept, but these changes make sure we don't modify the dom too much. Instead we just copy dom elements that Livewire changes, to the shadow dom. Some bugs remain though: https://github.com/livewire/livewire/discussions/5021